### PR TITLE
feat: v2.8.0 (db events metric)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -18,7 +18,11 @@ if config_env() == :prod do
     http: [
       port: String.to_integer(System.get_env("PORT") || "4000"),
       transport_options: [
-        max_connections: String.to_integer(System.get_env("MAX_CONNECTIONS") || "16384"),
+        # max_connection is per connection supervisor
+        # num_conns_sups defaults to num_acceptors
+        # total conns accepted here is max_connections * num_acceptors
+        # ref: https://ninenines.eu/docs/en/ranch/2.0/manual/ranch/
+        max_connections: String.to_integer(System.get_env("MAX_CONNECTIONS") || "1000"),
         num_acceptors: String.to_integer(System.get_env("NUM_ACCEPTORS") || "100"),
         # IMPORTANT: support IPv6 addresses
         socket_opts: [:inet6]

--- a/deploy/fly/prod.toml
+++ b/deploy/fly/prod.toml
@@ -24,9 +24,9 @@ processes = []
   protocol = "tcp"
   script_checks = []
   [services.concurrency]
-   # should match ranch.info
-    hard_limit = 16384
-    soft_limit = 16384
+   # should match :ranch.info max_connections * num_acceptors
+    hard_limit = 100000
+    soft_limit = 100000
     type = "connections"
 
   [[services.ports]]

--- a/lib/realtime/telemetry/logger.ex
+++ b/lib/realtime/telemetry/logger.ex
@@ -10,7 +10,8 @@ defmodule Realtime.Telemetry.Logger do
   @events [
     [:realtime, :connections],
     [:realtime, :rate_counter, :channel, :events],
-    [:realtime, :rate_counter, :channel, :joins]
+    [:realtime, :rate_counter, :channel, :joins],
+    [:realtime, :rate_counter, :channel, :db_events]
   ]
 
   def start_link(args \\ []) do

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -84,6 +84,19 @@ defmodule Realtime.Tenants do
     {:channel, :events, tenant.external_id}
   end
 
+  @doc """
+  The GenCounter key to use when counting events for RealtimeChannel events.
+  """
+
+  @spec db_events_per_second_key(Tenant.t() | String.t()) :: {:channel, :db_events, String.t()}
+  def db_events_per_second_key(tenant) when is_binary(tenant) do
+    {:channel, :db_events, tenant}
+  end
+
+  def db_events_per_second_key(%Tenant{} = tenant) do
+    {:channel, :db_events, tenant.external_id}
+  end
+
   @spec get_tenant_limits(Realtime.Api.Tenant.t(), maybe_improper_list) :: list
   def get_tenant_limits(%Tenant{} = tenant, keys) when is_list(keys) do
     nodes = [Node.self() | Node.list()]


### PR DESCRIPTION
This pull request introduces changes to improve connection handling, enhance tenant-specific event tracking, and optimize code readability and maintainability. Key updates include adjustments to connection limits, the addition of tenant-based database event tracking, and minor refactoring for consistency.

### Connection Handling Updates:
* Updated `max_connections` in `config/runtime.exs` to 1000 with additional documentation explaining the calculation of total connections using `num_acceptors`.
* Adjusted `hard_limit` and `soft_limit` in `deploy/fly/prod.toml` to 100,000 to align with the updated connection handling logic.

### Tenant-Specific Database Event Tracking:
* Introduced a `db_events_per_second_key` function in `lib/realtime/tenants.ex` to generate keys for tracking database events per tenant.
* Added a `start_db_rate_counter` function in `lib/realtime_web/channels/realtime_channel.ex` to initialize counters for tenant-specific database events.
* Integrated the new `db_events_per_second_key` into the message dispatcher to count database events per tenant. [[1]](diffhunk://#diff-12dced46c46ec51826fa7446fdd6b30b504926a8e09c4f9056daf35b5c528af2R46) [[2]](diffhunk://#diff-12dced46c46ec51826fa7446fdd6b30b504926a8e09c4f9056daf35b5c528af2R69-R73)

### Code Refactoring and Telemetry Enhancements:
* Removed unused aliases `GenCounter` and `Tenants` from `lib/extensions/postgres_cdc_rls/replication_poller.ex` for clarity.
* Added a new telemetry event `[:realtime, :rate_counter, :channel, :db_events]` in `lib/realtime/telemetry/logger.ex` for monitoring database events.